### PR TITLE
Enable draggable chips with mouse-drawn connections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,12 +7,15 @@
 }
 
 .chip {
+  position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
   background: #222;
   padding: 20px;
   border: 2px solid #555;
+  cursor: move;
+  user-select: none;
 }
 
 .inputs,
@@ -49,6 +52,7 @@
   align-items: center;
   justify-content: center;
   border: 1px solid #555;
+  position: relative;
 }
 
 .run {
@@ -57,9 +61,13 @@
 
 
 .workspace {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
+  height: 100vh;
+  user-select: none;
 }
 
 .workspace-io {
@@ -69,9 +77,32 @@
   margin-bottom: 20px;
 }
 
-.chips {
+.input-wrapper {
   display: flex;
-  gap: 20px;
-  flex-wrap: wrap;
-  justify-content: center;
+  align-items: center;
+  gap: 5px;
+}
+
+.port {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #888;
+}
+
+.port.output {
+  cursor: crosshair;
+}
+
+.port.input {
+  cursor: pointer;
+}
+
+.connections {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }

--- a/src/Chip.tsx
+++ b/src/Chip.tsx
@@ -1,49 +1,63 @@
 import './App.css'
-import type { ChangeEvent } from 'react'
+import type React from 'react'
 
 interface ChipProps {
   id: number
   code: string
   setCode: (code: string) => void
   outputs: string[]
-  inputSources: string[]
-  setInputSource: (port: number, source: string) => void
-  options: { value: string; label: string }[]
+  position: { x: number; y: number }
+  onDragStart: (id: number, e: React.MouseEvent<HTMLDivElement>) => void
+  registerPort: (id: string, el: HTMLDivElement | null) => void
+  startConnection: (id: string, e: React.MouseEvent<HTMLDivElement>) => void
+  finishConnection: (id: string) => void
 }
 
 export default function Chip({
+  id,
   code,
   setCode,
   outputs,
-  inputSources,
-  setInputSource,
-  options,
+  position,
+  onDragStart,
+  registerPort,
+  startConnection,
+  finishConnection,
 }: ChipProps) {
-  const handleSelect = (i: number) => (e: ChangeEvent<HTMLSelectElement>) => {
-    setInputSource(i, e.target.value)
-  }
-
   return (
-    <div className="chip">
+    <div
+      className="chip"
+      style={{ left: position.x, top: position.y }}
+      onMouseDown={(e) => onDragStart(id, e)}
+    >
       <div className="inputs">
-        {inputSources.map((src, i) => (
-          <select key={i} value={src} onChange={handleSelect(i)}>
-            {options.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+        {outputs.map((_, i) => (
+          <div
+            key={i}
+            className="port input"
+            ref={(el) => registerPort(`ci:${id}:${i}`, el)}
+            onMouseUp={() => finishConnection(`ci:${id}:${i}`)}
+          ></div>
         ))}
       </div>
-      <textarea className="code" value={code} onChange={(e) => setCode(e.target.value)} />
+      <textarea
+        className="code"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+      />
       <div className="outputs">
         {outputs.map((value, i) => (
           <div key={i} className="output">
             {value}
+            <div
+              className="port output"
+              ref={(el) => registerPort(`c:${id}:${i}`, el)}
+              onMouseDown={(e) => startConnection(`c:${id}:${i}`, e)}
+            ></div>
           </div>
         ))}
       </div>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- Make chip components draggable within the workspace
- Allow connecting ports via mouse-drawn lines instead of select boxes
- Style workspace, chips, and port connectors for interactive wiring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897237647488322b0d4f72192a98c2d